### PR TITLE
[Feat] 담당 도메인 기능 구현

### DIFF
--- a/src/main/java/devscaling/coin/CoinApplication.java
+++ b/src/main/java/devscaling/coin/CoinApplication.java
@@ -2,7 +2,9 @@ package devscaling.coin;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CoinApplication {
 

--- a/src/main/java/devscaling/coin/domain/controller/QnaBoardController.java
+++ b/src/main/java/devscaling/coin/domain/controller/QnaBoardController.java
@@ -1,0 +1,89 @@
+package devscaling.coin.domain.controller;
+
+import devscaling.coin.domain.dto.QnaBoardRequestDto;
+import devscaling.coin.domain.entity.QnaBoard;
+import devscaling.coin.domain.service.QnaBoardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/qna/board")
+public class QnaBoardController {
+
+    private final QnaBoardService qnaBoardService;
+
+    /**
+     * 생성폼 조회
+     */
+    @GetMapping("/create")
+    public String createQnaBoard(){
+        return "";
+    }
+
+    /**
+     * 생성폼 제출
+     */
+    @PostMapping("/create")
+    public String createQnaBoard(@ModelAttribute("qnaBoard") QnaBoardRequestDto qnaBoardRequestDto){
+        qnaBoardService.createQnaBoard(qnaBoardRequestDto);
+
+        return "";
+    }
+
+    /**
+     * 게시글 모두 조회
+     * 이후 pageable 활용 예정
+     */
+    @GetMapping("/")
+    public String getBoards(Model model){
+        List<QnaBoard> qnaBoardList = qnaBoardService.getQnaBoards();
+        model.addAttribute("qnaBoardList", qnaBoardList);
+        return "";
+    }
+
+    /**
+     * 단일 게시글 조회
+     */
+    @GetMapping("/{qnaBoardId}")
+    public String getBoard(@PathVariable("qnaBoardId") Long id, Model model){
+        model.addAttribute("qnaBoard",qnaBoardService.getQnaBoard(id));
+        return "";
+    }
+
+    /**
+     * 단일 게시글 수정 폼 조회
+     */
+    @GetMapping("/{qnaBoardId}/update")
+    public String updateQnaBoard(@PathVariable("qnaBoardId") Long id,
+                                 Model model){
+
+        model.addAttribute("qnaBoard", qnaBoardService.getQnaBoard(id));
+        return "";
+    }
+
+    /**
+     * 단일 게시글 수정 요청
+     */
+    @PostMapping("/{qnaBoardId}/update")
+    public String updateQnaBoard(@PathVariable("qnaBoardId") Long id,
+                                 @ModelAttribute("qnaBoard") QnaBoard qnaBoard){
+        qnaBoardService.updateQnaBoard(id, qnaBoard);
+        return "redirect:/qna/board/"+ id + "/update";
+    }
+
+
+    /**
+     * 단일 게시글 삭제
+     */
+    @PostMapping("/{qnaBoardId}/delete")
+    public String deleteQnaBoard(@PathVariable("qnaBoardId") Long id){
+        qnaBoardService.deleteQnaBoard(id);
+        return "redirect:/qna/board/";
+    }
+
+}

--- a/src/main/java/devscaling/coin/domain/controller/QnaCommentController.java
+++ b/src/main/java/devscaling/coin/domain/controller/QnaCommentController.java
@@ -1,0 +1,94 @@
+package devscaling.coin.domain.controller;
+
+
+import devscaling.coin.domain.dto.QnaCommentRequestDto;
+import devscaling.coin.domain.entity.QnaComment;
+import devscaling.coin.domain.service.QnaCommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class QnaCommentController {
+
+
+    private final QnaCommentService qnaCommentService;
+
+    /**
+     * 댓글 생성폼 조회
+     */
+    @GetMapping("/qna/{qnaBoardId}/comment/create")
+    public String createQnaBoard(@PathVariable("qnaBoardId") Long boardId){
+        return "";
+    }
+
+    /**
+     * 댓글 생성폼 제출
+     */
+    @PostMapping("/qna/{qnaBoardId}/comment/create")
+    public String createQnaBoard(@PathVariable("qnaBoardId") Long boardId,
+                                 @ModelAttribute("qnaComment") QnaCommentRequestDto qnaCommentRequestDto){
+        qnaCommentService.createQnaComment(boardId, qnaCommentRequestDto);
+
+        return "";
+    }
+
+    /**
+     * 댓글 모두 조회
+     * 이후 pageable 활용 예정
+     */
+    @GetMapping("/qna/{qnaBoardId}/comment")
+    public String getBoards(@PathVariable("qnaBoardId") Long boardId, Model model){
+        List<QnaComment> qnaComments = qnaCommentService.getQnaComments(boardId);
+        model.addAttribute("qnaComments", qnaComments);
+        return "";
+    }
+
+    /**
+     * 단일 댓글 조회
+     */
+    @GetMapping("/qna/{qnaBoardId}/comment/{qnaCommentId}")
+    public String getBoard(@PathVariable("qnaBoardId") Long boardId, Long qnaCommentId,
+                           Model model){
+        model.addAttribute("qnaComment",qnaCommentService.getQnaComment(boardId, qnaCommentId));
+        return "";
+    }
+
+    /**
+     * 단일 댓글 수정 폼 조회
+     */
+    @GetMapping("/qna/{qnaBoardId}/comment/{qnaCommentId}/update")
+    public String updateQnaBoard(@PathVariable("qnaBoardId") Long boardId, Long qnaCommentId,
+                                 Model model){
+        model.addAttribute("qnaComment",qnaCommentService.getQnaComment(boardId, qnaCommentId));
+        return "";
+    }
+
+    /**
+     * 단일 댓글 수정 요청
+     */
+    @PostMapping("/qna/{qnaBoardId}/comment/{qnaCommentId}/update")
+    public String updateQnaBoard(@PathVariable("qnaBoardId") Long boardId, Long qnaCommentId,
+                                 @ModelAttribute("qnaComment") QnaComment QnaComment){
+        qnaCommentService.updateQnaComment(boardId, qnaCommentId, QnaComment);
+        return "redirect:/qna/" + boardId + "/comment/" + qnaCommentId + "/update";
+    }
+
+
+    /**
+     * 단일 댓글 삭제
+     */
+    @PostMapping("/qna/{qnaBoardId}/comment/{qnaCommentId}/delete")
+    public String deleteQnaBoard(@PathVariable("qnaBoardId") Long boardId, Long qnaCommentId){
+        qnaCommentService.deleteQnaComment(boardId, qnaCommentId);
+        return "redirect:/qna/" + boardId;
+    }
+
+}

--- a/src/main/java/devscaling/coin/domain/dto/QnaBoardRequestDto.java
+++ b/src/main/java/devscaling/coin/domain/dto/QnaBoardRequestDto.java
@@ -1,0 +1,14 @@
+package devscaling.coin.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class QnaBoardRequestDto {
+
+    private String title;
+    private String content;
+    private String userName;
+    private String password;
+
+}

--- a/src/main/java/devscaling/coin/domain/dto/QnaCommentRequestDto.java
+++ b/src/main/java/devscaling/coin/domain/dto/QnaCommentRequestDto.java
@@ -1,0 +1,15 @@
+package devscaling.coin.domain.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class QnaCommentRequestDto {
+
+    private String content;
+    private String userName;
+    private String password;
+
+    // 멤버의 등급 필드
+
+}

--- a/src/main/java/devscaling/coin/domain/entity/Anonymous.java
+++ b/src/main/java/devscaling/coin/domain/entity/Anonymous.java
@@ -1,0 +1,33 @@
+package devscaling.coin.domain.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "ANONYMOUS")
+public class Anonymous extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "anonymous_id")
+    private Long id;
+
+    @Column(length = 150, nullable = false)
+    private String password;
+
+    @OneToMany(mappedBy = "anonymousMember", orphanRemoval = true)
+    @Builder.Default
+    private List<QnaBoard> qnaBoards = new ArrayList<>();
+
+
+
+}

--- a/src/main/java/devscaling/coin/domain/entity/BaseEntity.java
+++ b/src/main/java/devscaling/coin/domain/entity/BaseEntity.java
@@ -1,0 +1,26 @@
+package devscaling.coin.domain.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, nullable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+}

--- a/src/main/java/devscaling/coin/domain/entity/QnaBoard.java
+++ b/src/main/java/devscaling/coin/domain/entity/QnaBoard.java
@@ -1,0 +1,47 @@
+package devscaling.coin.domain.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+@Entity
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "QNABOARD")
+public class QnaBoard extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "qnaboard_id")
+    private Long id;
+
+    @Column(length = 50)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+
+    @OneToMany(mappedBy = "qnaBoards", orphanRemoval = true)
+    @Builder.Default
+    private List<QnaComment> qnaComments = new ArrayList<>();
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "anonymous_id")
+    private Anonymous anonymousMember;
+
+    public void setAnonymousQnaBoard(Anonymous anonymous) {
+        this.anonymousMember = anonymous;
+        anonymous.getQnaBoards().add(this);
+    }
+
+    //일반고객 연관관계 설정 필요
+
+}

--- a/src/main/java/devscaling/coin/domain/entity/QnaBoard.java
+++ b/src/main/java/devscaling/coin/domain/entity/QnaBoard.java
@@ -1,6 +1,7 @@
 package devscaling.coin.domain.entity;
 
 
+
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -14,7 +15,7 @@ import java.util.List;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "QNABOARD")
+@Table(name = "qna_board")
 public class QnaBoard extends BaseEntity {
 
     @Id
@@ -43,5 +44,11 @@ public class QnaBoard extends BaseEntity {
     }
 
     //일반고객 연관관계 설정 필요
+
+
+    public void updateQnaBoard(QnaBoard qnaBoard){
+        this.title = qnaBoard.getTitle();
+        this.content = qnaBoard.getContent();
+    }
 
 }

--- a/src/main/java/devscaling/coin/domain/entity/QnaComment.java
+++ b/src/main/java/devscaling/coin/domain/entity/QnaComment.java
@@ -1,0 +1,32 @@
+package devscaling.coin.domain.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@ToString
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "QNACOMMENT")
+public class QnaComment extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "qnacomment_id")
+    private Long id;
+
+    @Column(length = 200, nullable = false)
+    private String content;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "qnaboard_id")
+    private QnaBoard qnaBoards;
+
+    public void setQnaBoardQnaComment(QnaBoard qnaBoards) {
+        this.qnaBoards = qnaBoards;
+        qnaBoards.getQnaComments().add(this);
+    }
+
+}

--- a/src/main/java/devscaling/coin/domain/entity/QnaComment.java
+++ b/src/main/java/devscaling/coin/domain/entity/QnaComment.java
@@ -29,4 +29,8 @@ public class QnaComment extends BaseEntity {
         qnaBoards.getQnaComments().add(this);
     }
 
+    public void updateQnaComment(String content) {
+        this.content = content;
+    }
+
 }

--- a/src/main/java/devscaling/coin/domain/repository/AnonymousRepository.java
+++ b/src/main/java/devscaling/coin/domain/repository/AnonymousRepository.java
@@ -1,0 +1,8 @@
+package devscaling.coin.domain.repository;
+
+import devscaling.coin.domain.entity.Anonymous;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnonymousRepository extends JpaRepository<Anonymous, Long> {
+
+}

--- a/src/main/java/devscaling/coin/domain/repository/QnaBoardRepository.java
+++ b/src/main/java/devscaling/coin/domain/repository/QnaBoardRepository.java
@@ -1,0 +1,8 @@
+package devscaling.coin.domain.repository;
+
+import devscaling.coin.domain.entity.QnaBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnaBoardRepository extends JpaRepository<QnaBoard, Long> {
+
+}

--- a/src/main/java/devscaling/coin/domain/repository/QnaCommentRepository.java
+++ b/src/main/java/devscaling/coin/domain/repository/QnaCommentRepository.java
@@ -1,0 +1,8 @@
+package devscaling.coin.domain.repository;
+
+import devscaling.coin.domain.entity.QnaComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QnaCommentRepository extends JpaRepository<QnaComment, Long> {
+
+}

--- a/src/main/java/devscaling/coin/domain/service/QnaBoardService.java
+++ b/src/main/java/devscaling/coin/domain/service/QnaBoardService.java
@@ -1,0 +1,74 @@
+package devscaling.coin.domain.service;
+
+import devscaling.coin.domain.dto.QnaBoardRequestDto;
+import devscaling.coin.domain.entity.Anonymous;
+import devscaling.coin.domain.entity.QnaBoard;
+import devscaling.coin.domain.repository.AnonymousRepository;
+import devscaling.coin.domain.repository.QnaBoardRepository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+/**
+ * UPDATE, DELETE의 경우, 인증된 사용자만 삭제할 수 있도록 이후 추가로직 구현 필요
+ */
+@Service
+@RequiredArgsConstructor
+public class QnaBoardService {
+
+
+    private final QnaBoardRepository qnaBoardRepository;
+    private final AnonymousRepository anonymousRepository;
+
+
+    @Transactional
+    public void createQnaBoard(QnaBoardRequestDto qnaBoardRequestDto){
+        QnaBoard qnaBoard = QnaBoard.builder()
+                .title(qnaBoardRequestDto.getTitle())
+                .content(qnaBoardRequestDto.getContent())
+                .build();
+
+        if(!qnaBoardRequestDto.getUserName().isEmpty()){
+
+
+            return;
+        }
+        Anonymous anonymous = Anonymous.builder()
+                .password(qnaBoardRequestDto.getPassword())
+                .build();
+        anonymousRepository.save(anonymous);
+        qnaBoard.setAnonymousQnaBoard(anonymous);
+        qnaBoardRepository.save(qnaBoard);
+    }
+
+    @Transactional
+    public void updateQnaBoard(Long id, QnaBoard qnaBoard){
+        QnaBoard findQnaBoard = qnaBoardRepository.findById(id).get();
+
+        if(findQnaBoard == null){
+
+        }
+
+        findQnaBoard.updateQnaBoard(qnaBoard);
+    }
+
+    @Transactional(readOnly = true)
+    public QnaBoard getQnaBoard(Long id){
+        return qnaBoardRepository.findById(id).get();
+    }
+
+    @Transactional(readOnly = true)
+    public List<QnaBoard> getQnaBoards(){
+        return qnaBoardRepository.findAll();
+    }
+
+    @Transactional
+    public void deleteQnaBoard(Long id){
+        qnaBoardRepository.deleteById(id);
+    }
+
+}

--- a/src/main/java/devscaling/coin/domain/service/QnaCommentService.java
+++ b/src/main/java/devscaling/coin/domain/service/QnaCommentService.java
@@ -1,0 +1,64 @@
+package devscaling.coin.domain.service;
+
+import devscaling.coin.domain.dto.QnaCommentRequestDto;
+import devscaling.coin.domain.entity.QnaBoard;
+import devscaling.coin.domain.entity.QnaComment;
+import devscaling.coin.domain.repository.QnaBoardRepository;
+import devscaling.coin.domain.repository.QnaCommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QnaCommentService {
+
+    private final QnaBoardRepository qnaBoardRepository;
+    private final QnaCommentRepository qnaCommentRepository;
+
+
+    @Transactional
+    public void createQnaComment(Long qnaBoardId, QnaCommentRequestDto qnaCommentRequestDto){
+        QnaComment qnaComment = QnaComment.builder()
+                .content(qnaCommentRequestDto.getContent())
+                .build();
+
+        // 관리자인지 검증하는 기능
+        QnaBoard qnaBoard = qnaBoardRepository.findById(qnaBoardId).get();
+        qnaComment.setQnaBoardQnaComment(qnaBoard);
+        qnaCommentRepository.save(qnaComment);
+    }
+
+    @Transactional
+    public void updateQnaComment(Long qnaBoardId , Long qnaCommentId, QnaComment qnaComment){
+        /**
+         * 이후 Querydsl 연결해서 해결할 예정
+         */
+    }
+
+    @Transactional(readOnly = true)
+    public QnaComment getQnaComment(Long qnaBoardId , Long qnaCommentId){
+        /**
+         * 이후 Querydsl 연결해서 해결할 예정
+         */
+        return null;
+    }
+
+    @Transactional(readOnly = true)
+    public List<QnaComment> getQnaComments(Long qnaBoardId){
+        /**
+         * 이후 Querydsl 연결해서 해결할 예정
+         */
+        return null;
+    }
+
+    @Transactional
+    public void deleteQnaComment(Long qnaBoardId , Long qnaCommentId){
+        /**
+         * 이후 Querydsl 연결해서 해결할 예정
+         */
+    }
+
+}

--- a/src/test/java/devscaling/coin/domain/repository/AnonymousRepositoryTest.java
+++ b/src/test/java/devscaling/coin/domain/repository/AnonymousRepositoryTest.java
@@ -1,0 +1,39 @@
+package devscaling.coin.domain.repository;
+
+
+import devscaling.coin.domain.entity.Anonymous;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class AnonymousRepositoryTest {
+
+    @Autowired
+    AnonymousRepository anonymousRepository;
+
+    Anonymous anonymous;
+
+    @BeforeEach
+    void before(){
+        anonymous = Anonymous.builder()
+                .password("1234")
+                .build();
+    }
+
+
+    @Test
+    @DisplayName("익명유저가 잘 저장되는지 테스트")
+    void saveAnonymousTest(){
+        Long id = anonymousRepository.save(anonymous).getId();
+
+        assertThat(anonymous.getPassword())
+                .isEqualTo(anonymousRepository.findById(id).
+                        get().getPassword());
+    }
+
+}

--- a/src/test/java/devscaling/coin/domain/repository/QnaBoardRepositoryTest.java
+++ b/src/test/java/devscaling/coin/domain/repository/QnaBoardRepositoryTest.java
@@ -2,7 +2,6 @@ package devscaling.coin.domain.repository;
 
 import devscaling.coin.domain.entity.Anonymous;
 import devscaling.coin.domain.entity.QnaBoard;
-import devscaling.coin.domain.entity.QnaComment;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -22,7 +21,6 @@ class QnaBoardRepositoryTest {
 
     Anonymous anonymous;
     QnaBoard qnaBoard;
-    QnaComment qnaComment;
 
     @BeforeEach
     void before(){

--- a/src/test/java/devscaling/coin/domain/repository/QnaBoardRepositoryTest.java
+++ b/src/test/java/devscaling/coin/domain/repository/QnaBoardRepositoryTest.java
@@ -1,0 +1,68 @@
+package devscaling.coin.domain.repository;
+
+import devscaling.coin.domain.entity.Anonymous;
+import devscaling.coin.domain.entity.QnaBoard;
+import devscaling.coin.domain.entity.QnaComment;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+@DataJpaTest
+class QnaBoardRepositoryTest {
+
+    @Autowired
+    QnaBoardRepository qnaBoardRepository;
+    @Autowired
+    AnonymousRepository anonymousRepository;
+
+    Anonymous anonymous;
+    QnaBoard qnaBoard;
+    QnaComment qnaComment;
+
+    @BeforeEach
+    void before(){
+        qnaBoard = QnaBoard.builder()
+                .title("시스템 오류")
+                .content("장애 확인 바람")
+                .build();
+        anonymous = Anonymous.builder()
+                .password("1234")
+                .build();
+    }
+
+    @Test
+    @DisplayName("QnA게시판에 잘 저장되는지 테스트")
+    void saveQnaBoardTest(){
+        Long id = qnaBoardRepository.save(qnaBoard).getId();
+
+        assertThat(qnaBoard.getContent())
+                .isEqualTo(qnaBoardRepository
+                        .findById(id)
+                        .get()
+                        .getContent());
+        assertThat(qnaBoard.getTitle())
+                .isEqualTo(qnaBoardRepository
+                        .findById(id)
+                        .get()
+                        .getTitle());
+    }
+
+    @Test
+    @DisplayName("익명유저 - QnA게시판간 연관관계 테스트")
+    void correlationTest(){
+        Long id = anonymousRepository.save(anonymous).getId();
+        qnaBoard.setAnonymousQnaBoard(anonymous);
+        qnaBoardRepository.save(qnaBoard);
+
+
+        assertThat(qnaBoard.getAnonymousMember().getPassword())
+                .isEqualTo(anonymousRepository.findById(id)
+                        .get().getPassword());
+    }
+
+}

--- a/src/test/java/devscaling/coin/domain/repository/QnaCommentRepositoryTest.java
+++ b/src/test/java/devscaling/coin/domain/repository/QnaCommentRepositoryTest.java
@@ -1,0 +1,65 @@
+package devscaling.coin.domain.repository;
+
+import devscaling.coin.domain.entity.Anonymous;
+import devscaling.coin.domain.entity.QnaBoard;
+import devscaling.coin.domain.entity.QnaComment;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class QnaCommentRepositoryTest {
+
+    @Autowired
+    QnaCommentRepository qnaCommentRepository;
+    @Autowired
+    QnaBoardRepository qnaBoardRepository;
+
+    QnaBoard qnaBoard;
+    QnaComment qnaComment;
+
+    @BeforeEach
+    void before(){
+        qnaBoard = QnaBoard.builder()
+                .title("시스템 오류")
+                .content("장애 확인 바람")
+                .build();
+        qnaComment = QnaComment.builder()
+                .content("조치했습니다.")
+                .build();
+    }
+
+    @Test
+    @DisplayName("qnaComment가 잘 저장되는지 테스트")
+    void saveQnaCommentTest(){
+        Long id = qnaCommentRepository.save(qnaComment).getId();
+
+        assertThat(qnaComment.getContent())
+                .isEqualTo(qnaCommentRepository.findById(id)
+                        .get()
+                        .getContent());
+    }
+
+    @Test
+    @DisplayName("QnA게시판 - QnA댓글 간 연관관계 테스트")
+    void correlationTest(){
+        Long id = qnaBoardRepository.save(qnaBoard).getId();
+        qnaComment.setQnaBoardQnaComment(qnaBoard);
+        qnaCommentRepository.save(qnaComment);
+
+        assertThat(qnaComment.getQnaBoards().getTitle())
+                .isEqualTo(qnaBoardRepository.findById(id)
+                        .get()
+                        .getTitle());
+        assertThat(qnaComment.getQnaBoards().getContent())
+                .isEqualTo(qnaBoardRepository.findById(id)
+                        .get()
+                        .getContent());
+    }
+
+}


### PR DESCRIPTION
## PR 타입
-[x] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 반영 브랜치
ex) hwangjeyeon/domain-> dev

### 변경 사항
- qnaBoard, qnaComment, Anonymous domain 기능 구현했습니다
- 담당 도메인 Repository 기능 구현했습니다
- qnaBoard, qnaComment CRUD 서비스 기능 구현했습니다
- MVC 컨트롤러 틀만 구현했습니다. (프론트 페이지 부재 문제)
- 모델 dto 구현했습니다.
